### PR TITLE
Export "Mask Feather"

### DIFF
--- a/bundle/jsx/utils/maskHelper.jsx
+++ b/bundle/jsx/utils/maskHelper.jsx
@@ -44,6 +44,9 @@ $.__bodymovin.bm_maskHelper = (function () {
             $.__bodymovin.bm_shapeHelper.checkVertexCount(shapeData.pt.k);
             shapeData.o = bm_keyframeHelper.exportKeyframes(maskElement.property('Mask Opacity'), frameRate, stretch);
             shapeData.x = bm_keyframeHelper.exportKeyframes(maskElement.property('Mask Expansion'), frameRate, stretch);
+            if ($.__bodymovin.bm_renderManager.shouldIncludeNotSupportedProperties()) {
+                shapeData.f = bm_keyframeHelper.exportKeyframes(maskElement.property('Mask Feather'), frameRate, stretch);
+            }
             shapeData.nm = maskElement.name;
             layerData.masksProperties.push(shapeData);
         }


### PR DESCRIPTION
Add the option (guarded by "Include non supported properties") to export mask "feathers" params.