### PR TITLE
Export motion blur parameters

### DIFF
--- a/bundle/jsx/elements/layerElement.jsx
+++ b/bundle/jsx/elements/layerElement.jsx
@@ -155,6 +155,9 @@ $.__bodymovin.bm_layerElement = (function () {
         layerData.st = layerInfo.startTime * frameRate;
         if ($.__bodymovin.bm_renderManager.shouldIncludeNotSupportedProperties()) {
             layerData.cp = layerInfo.collapseTransformation;
+            if (layerInfo.motionBlur) {
+                layerData.mb = true;
+            }
         }
         layerData.bm = bm_blendModes.getBlendMode(layerInfo.blendingMode);
         

--- a/bundle/jsx/renderManager.jsx
+++ b/bundle/jsx/renderManager.jsx
@@ -164,9 +164,21 @@ $.__bodymovin.bm_renderManager = (function () {
         createLayers(comp, exportData.layers, exportData.fr, true);
         exportExtraComps(exportData);
         exportCompMarkers(exportData, comp);
+        exportMotionBlur(exportData, comp);
         totalLayers = pendingLayers.length;
         currentLayer = 0;
         app.scheduleTask('$.__bodymovin.bm_renderManager.renderNextLayer();', 20, false);
+    }
+
+    function exportMotionBlur(exportData, comp) {
+        if (comp.motionBlur && shouldIncludeNotSupportedProperties()) {
+            exportData.mb = {
+              sa : comp.shutterAngle,
+              sp : comp.shutterPhase,
+              spf: comp.motionBlurSamplesPerFrame,
+              asl: comp.motionBlurAdaptiveSampleLimit
+            };
+        }
     }
 
     function exportCompMarkers(exportData, comp) {


### PR DESCRIPTION
Top-level composition:

  mb: {
    sa:  compItem.shutterAngle,  // [1]
    sp:  compItem.shutterPhase, // [2]
    spf: compItem.motionBlurSamplesPerFrame, // [3]
    asl: compItem.adaptiveSampleLimit // [4]
  }

Per-layer:

  mb: avLayer.motionBlur // [5]

Note: these are only exported with BM's "Include non supported properties" option, AND when motion blur is active (motion blur is disabled by default).

[1] http://docs.aenhancers.com/items/compitem/#compitem-shutterangle
[2] http://docs.aenhancers.com/items/compitem/#compitem-shutterphase
[3] http://docs.aenhancers.com/items/compitem/#compitem-motionblursamplesperframe
[4] http://docs.aenhancers.com/items/compitem/#compitem-motionbluradaptivesamplelimit
[5] http://docs.aenhancers.com/layers/avlayer/#avlayer-motionblur