### PR TITLE
Export square selector Smoothness property

### DIFF
--- a/bundle/jsx/utils/textAnimatorHelper.jsx
+++ b/bundle/jsx/utils/textAnimatorHelper.jsx
@@ -22,6 +22,9 @@ $.__bodymovin.bm_textAnimatorHelper = (function () {
             ob.b = advancedProperty.property("ADBE Text Range Type2").value;
             ob.rn = advancedProperty.property("ADBE Text Randomize Order").value;
             ob.sh = advancedProperty.property("ADBE Text Range Shape").value;
+            if (ob.sh === 1 && $.__bodymovin.bm_renderManager.shouldIncludeNotSupportedProperties()) {
+                ob.sm = bm_keyframeHelper.exportKeyframes(advancedProperty.property('ADBE Text Selector Smoothness'), frameRate, stretch);
+            }
 
             // 
             var rangeUnits = advancedProperty.property('ADBE Text Range Units').value;


### PR DESCRIPTION
In addition to the usual properties, square range selectors have a Smoothness adjustment (which controls the slope of the leading/trailing shape edges): https://helpx.adobe.com/after-effects/using/animating-text.html#Smoothness
