### PR TITLE
Export 'blur' text animator property

### DIFF
--- a/bundle/jsx/utils/textAnimatorHelper.jsx
+++ b/bundle/jsx/utils/textAnimatorHelper.jsx
@@ -165,6 +165,9 @@ $.__bodymovin.bm_textAnimatorHelper = (function () {
                 case 'ADBE Text Skew Axis':
                     ob.sa = bm_keyframeHelper.exportKeyframes(property, frameRate, stretch);
                     break;
+                case 'ADBE Text Blur':
+                    ob.bl = bm_keyframeHelper.exportKeyframes(property, frameRate, stretch);
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Add support for exporting text animator blurs.

(https://helpx.adobe.com/after-effects/using/animating-text.html#text_animator_properties)