### PR TITLE
Export text line spacing prop

### DIFF
--- a/bundle/jsx/utils/textAnimatorHelper.jsx
+++ b/bundle/jsx/utils/textAnimatorHelper.jsx
@@ -168,6 +168,9 @@ $.__bodymovin.bm_textAnimatorHelper = (function () {
                 case 'ADBE Text Blur':
                     ob.bl = bm_keyframeHelper.exportKeyframes(property, frameRate, stretch);
                     break;
+                case 'ADBE Text Line Spacing':
+                    ob.ls = bm_keyframeHelper.exportKeyframes(property, frameRate, stretch);
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Export the "Line Spacing" text animator property (match name: 'ADBE Text Line Spacing') as "ls".