### PR TITLE
Fix how sanitized asset names are incremented

### DIFF
--- a/bundle/jsx/utils/sourceHelper.jsx
+++ b/bundle/jsx/utils/sourceHelper.jsx
@@ -135,9 +135,9 @@ $.__bodymovin.bm_sourceHelper = (function () {
             } else {
                 sanitizedName += '_'
             }
-            if(checkSanitizedNameExists(sanitizedName + extension)){
-                sanitizedName = incrementSanizitedName(sanitizedName)
-            }
+        }
+        if(checkSanitizedNameExists(sanitizedName + extension)){
+            sanitizedName = incrementSanizitedName(sanitizedName)
         }
         return sanitizedName + extension;
     }


### PR DESCRIPTION
If a comp has the following files:

- File 1.png
- File 2.png
- File 11.png

The extension currently will unnecessarily sanitize and rename the `File 11.png` as `File_1_01.png` instead of `File_11.png`. This PR fixes that.

Thanks!