### PR TITLE
Fix image sequences export

### DIFF
--- a/bundle/jsx/utils/sourceHelper.jsx
+++ b/bundle/jsx/utils/sourceHelper.jsx
@@ -399,7 +399,7 @@ $.__bodymovin.bm_sourceHelper = (function () {
         }
         if (lastMatch) {
             var value = lastMatch[0]
-            var num = parseInt(value) + index
+            var num = parseInt(value, 10) + index
             var newValue = num.toString()
             var count = 0;
             while(newValue.length < value.length) {


### PR DESCRIPTION
Currently, if an image sequence's name starts with leading zeros, the extension does not export it properly. 

The reason why that happens is that older versions of JS, specifically ES3 (which AE's ExtendScript is based on), parses the string as octal when it has leading zeros. That functionality has been deprecated and removed in later versions of JS but it stayed around in ES3. 

This PR forces parseInt to parse with radix =10, thus eliminating the issue. Here's how the image sequence looked for me in my AE project:
![image](https://user-images.githubusercontent.com/2637884/102496408-5cdf6f00-4045-11eb-93f5-ff464a17be79.png)

You can read more on that issue here: https://stackoverflow.com/questions/8763396/javascript-parseint-with-leading-zeros 