### PR TITLE
Get appdata path of the current user in gulpfile dynamically

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 var gulp = require('gulp'); 
 var watch = require('gulp-watch');
 var htmlreplace = require('gulp-html-replace');
@@ -11,7 +13,7 @@ var insert = require('gulp-insert');
 var version = '5.7.8'
 
 var extensionSource = './bundle';
-var extensionDestination = '../../../tropi/AppData/Roaming/Adobe/CEP/extensions/bodymovin';
+var extensionDestination = path.join(process.env.APPDATA || (process.platform === 'darwin' ? process.env.HOME + '/Library/Application Support' : '.'), 'Adobe/CEP/extensions/bodymovin');
 gulp.task('watch-extension', function() {
     gulp.src(extensionSource + '/**/*', {base: extensionSource})
         .pipe(watch(extensionSource, {base: extensionSource}))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,7 @@ var insert = require('gulp-insert');
 var version = '5.7.8'
 
 var extensionSource = './bundle';
-var extensionDestination = path.join(process.env.APPDATA || (process.platform === 'darwin' ? process.env.HOME + '/Library/Application Support' : '.'), 'Adobe/CEP/extensions/bodymovin');
+var extensionDestination = path.join(process.env.APPDATA || (process.platform === 'darwin' ? path.join(process.env.HOME, '/Library/Application Support') : '.'), 'Adobe/CEP/extensions/bodymovin');
 gulp.task('watch-extension', function() {
     gulp.src(extensionSource + '/**/*', {base: extensionSource})
         .pipe(watch(extensionSource, {base: extensionSource}))


### PR DESCRIPTION
Removes need for other developers to set `extensionDestination` dynamically in gulpfile.

Works on OSX and Windows, on anything else it'll just default to the CWD