### PR TITLE
Support non-ascii gradient data

### DIFF
--- a/bundle/jsx/utils/ProjectParser.jsx
+++ b/bundle/jsx/utils/ProjectParser.jsx
@@ -28,7 +28,7 @@ $.__bodymovin.bm_ProjectHelper = (function(){
         } else {
             var demoFile = new File(ff.absoluteURI);
             demoFile.open('r', 'TEXT', '????');
-            //demoFile.encoding = 'UTF-8';
+            demoFile.encoding = 'BINARY';
             fileString = demoFile.read(demoFile.length);
         }
     }
@@ -44,6 +44,13 @@ $.__bodymovin.bm_ProjectHelper = (function(){
         }
     }
 
+    function toUTF8ByteString(str) {
+        var uriEncoded = encodeURIComponent(str);
+        return uriEncoded.replace(/%([0-9A-F]{2})/g, function(match, p1) {
+            return String.fromCharCode('0x' + p1);
+        });
+    }
+
     function getGradientData(shapeNavigation, numKeys){
         if(!fileString){
             getProjectData();
@@ -56,14 +63,14 @@ $.__bodymovin.bm_ProjectHelper = (function(){
         var gradientIndex = 0, navigationIndex = 0;
         var i = 0, len = shapeNavigation.length;
         while (i < len) {
-            var encoded = unescape(encodeURIComponent(shapeNavigation[i] + 'LIST'));
+            var encoded = toUTF8ByteString(shapeNavigation[i] + 'LIST');
             var stringIndex = fileString.indexOf(encoded, navigationIndex + 1);
             if (stringIndex === -1) {
-                encoded = unescape(encodeURIComponent(shapeNavigation[i] + ' LIST'));
+                encoded = toUTF8ByteString(shapeNavigation[i] + ' LIST');
                 stringIndex = fileString.indexOf(encoded, navigationIndex + 1);
             }
             if (stringIndex === -1) {
-                encoded = unescape(encodeURIComponent(shapeNavigation[i]));
+                encoded = toUTF8ByteString(shapeNavigation[i]);
                 stringIndex = fileString.indexOf(encoded, navigationIndex + 1);
             }
             navigationIndex = stringIndex;


### PR DESCRIPTION
When effect path (composition names, layer names, etc.) contains CJK characters, the extension failed to parse gradient data and exported black-and-whites. The bug was reported on https://github.com/airbnb/lottie-web/issues/1201. This commit fixes it by adding support for parsing non-ascii gradient data.

In my test aep files, these characters are utf-8 encoded. However, reading the file with `encoding = 'UTF-8'` failed because of binary data out of utf-8 byte ranges. Conversely, I tried to read the file as binary string and encode `shapeNavigation`s the same way, so that we can find the correct `gradientIndex`.

Tested on After Effects 2021 (18.0.0) for MacOS. Both of AE and OS are Chinese version. Here is the demo aep file.

[Chinese gradient demo.aep.zip](https://github.com/bodymovin/bodymovin-extension/files/7734812/Chinese.gradient.demo.aep.zip)

Before:
![image](https://user-images.githubusercontent.com/7821581/146540464-767d8247-ef28-41e2-a4e1-fbeadf8b831d.png)


After:
![image](https://user-images.githubusercontent.com/7821581/146540262-3dd7f6c9-ccbb-4b44-beeb-a68166447b37.png)

