### PR TITLE
Update the match name when converting Easy Levels -> Pro Levels

### DIFF
--- a/bundle/jsx/utils/effectsHelper.jsx
+++ b/bundle/jsx/utils/effectsHelper.jsx
@@ -103,13 +103,13 @@ $.__bodymovin.bm_effectsHelper = (function () {
         }
     }
 
-    function setupBasicEffect(elem, effectType) {
+    function setupBasicEffect(elem, effectType, matchName) {
         var ob = {};
         ob.ty = effectType;
         ob.nm = elem.name;
         // Apparently numProperties returns 1 less value than the one used on expressions.
         ob.np = elem.numProperties + 1;
-        ob.mn = elem.matchName;
+        ob.mn = matchName;
         ob.ix = elem.propertyIndex;
         ob.en = elem.enabled === true ? 1 : 0;
         ob.ef = [];
@@ -638,10 +638,14 @@ $.__bodymovin.bm_effectsHelper = (function () {
         }
         // using matchName here instead of effectType, 
         // because this effect is still exported as an unknown effect (group)
-        var ob = setupBasicEffect(elem, effectType);
-        if (elem.matchName === 'ADBE Easy Levels2') { 
+        if (elem.matchName === 'ADBE Easy Levels2') {
+            // Convert to ProLevels.
+            var ob = setupBasicEffect(elem, effectType, 'ADBE Pro Levels2');
             return handleEasyLevels(elem, ob, frameRate, stretch);
-        } else if (elem.matchName === 'ADBE HUE SATURATION') {
+        }
+
+        var ob = setupBasicEffect(elem, effectType, elem.matchName);
+        if (elem.matchName === 'ADBE HUE SATURATION') {
             handleHueSaturation(elem);
         }
         var i, len = elem.numProperties, prop;


### PR DESCRIPTION
Starting in https://github.com/fmalita/bodymovin-extension/commit/93b54d6c0fa15f9ea5407436ddae4ce99ed41c38, Easy Levels are converted to Pro Levels -- but the effect match name remained "ADBE Pro Levels2".

This is confusing for e.g. Skottie, which relies on the match name to identify effects.

To fix, we should also update the match name when converting.