### PR TITLE
Fix precomp refId when "Use composition names as ids" is disabled

### DIFF
--- a/bundle/jsx/elements/layerElement.jsx
+++ b/bundle/jsx/elements/layerElement.jsx
@@ -117,7 +117,7 @@ $.__bodymovin.bm_layerElement = (function () {
                 if (settingsHelper.shouldUseCompNamesAsIds()) {
                     layerData.compId = layerInfo.source.name;
                 } else {
-                    layerData.compId = + compCount;
+                    layerData.compId = 'comp_' + compCount;
                 }
                 layerData.compName = layerInfo.source.name;
                 layerData.frameRate = layerInfo.source.frameRate;


### PR DESCRIPTION
After https://github.com/bodymovin/bodymovin-extension/commit/18947ca612ffeadfdb3be687576189335f61c064, when "Use composition names as ids" is disabled, exporting precomps produces invalid refIds (e.g. refId: 0).

This restores the old behavior.