### PR TITLE
Try to fix export curve data error

### DIFF
--- a/bundle/jsx/utils/keyframeHelper.jsx
+++ b/bundle/jsx/utils/keyframeHelper.jsx
@@ -268,8 +268,10 @@ $.__bodymovin.bm_keyframeHelper = (function () {
                                 } else {
                                     yNormal = (key.value[k] - lastKey.value[k]);
                                 }
+                                var nmlFlag = true;
                                 if(Math.abs(yNormal) < 0.0000001) {
                                     yNormal = 1;
+                                    nmlFlag = false;
                                 }
                                 // bm_eventDispatcher.log('yNormal')
                                 // bm_eventDispatcher.log(yNormal)
@@ -283,6 +285,10 @@ $.__bodymovin.bm_keyframeHelper = (function () {
                                 // bm_eventDispatcher.log(bezierInY)
                                 bezierIn.y[k] = 1 - (bezierInY*duration)/yNormal;
                                 bezierOut.y[k] = (bezierY*duration)/yNormal;
+                                if(!nmlFlag)
+                                {
+                                    bezierIn.y[k] = -(bezierInY*duration)/yNormal;
+                                }
                             }
                         }
                         break;


### PR DESCRIPTION
![image](https://github.com/bodymovin/bodymovin-extension/assets/20896273/eaebbb56-38f3-42d6-8a90-76de4e9f8a6c)

when we make a bezier curve with 2 key frames whose value are equal,  it seems that we export the bezier curve with error intangent data.